### PR TITLE
Make shorter toDateString

### DIFF
--- a/src/utils/toDateString.ts
+++ b/src/utils/toDateString.ts
@@ -1,5 +1,5 @@
 export default function toDateString(date: Date): string {
-  return `${date.toLocaleDateString()} ${toLocaleString("en-US", {
+  return `${date.toLocaleDateString()} ${date.toLocaleString("en-US", {
     timeStyle: "long",
   })}`;
 }

--- a/src/utils/toDateString.ts
+++ b/src/utils/toDateString.ts
@@ -1,13 +1,5 @@
 export default function toDateString(date: Date): string {
-  const hours12 = date.getHours() % 12;
-  const paddedHours = hours12.toString().padStart(2, '0');
-  const paddedMinutes = date.getMinutes().toString().padStart(2, '0');
-  const paddedSeconds = date.getSeconds().toString().padStart(2, '0');
-  const ampm = date.getHours() < 12 ? 'AM' : 'PM';
-  const timeOffset = new Date().getTimezoneOffset();
-  return `${date.toLocaleDateString()} ${paddedHours}:${paddedMinutes}:${paddedSeconds} ${ampm} UTC${
-    timeOffset < 0 ? '+' : '-'
-  }${Math.abs(Math.floor(timeOffset / 60))}:${Math.abs(timeOffset % 60)
-    .toString()
-    .padStart(2, '0')}`;
+  return `${date.toLocaleDateString()} ${toLocaleString("en-US", {
+    timeStyle: "long",
+  })}`;
 }


### PR DESCRIPTION
technically we could just do
```js
return date.toLocaleString("en-US", {
    dateStyle: "short",
    timeStyle: "long",
  })
// '11/26/22, 11:54:17 AM GMT+7'
  ```
but that would result in an extra comma
