### PR TITLE
Persist 2fa registration modal on failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "preview": "vite preview --host"
   },
   "dependencies": {
-    "@simplewebauthn/browser": "^10.0.0",
+    "@simplewebauthn/browser": "^11.0.0",
     "@vueuse/components": "^10.11.0",
     "@vueuse/core": "^10.11.0",
     "cumulonimbus-wrapper": "^5.0.0",


### PR DESCRIPTION
This allows the frontend to persist the 2fa registration modal in the event that the registration fails, saving users time from having to go through the first step again.

this PR also upgrades the `@simplewebauthn/browser` dependency to version `11.0.0`, matching the server's update made in commit https://github.com/AlekEagle/cumulonimbus-api/commit/84b5402ccc7be396e6a3c1f063c8982b78ebb77c. 

CU-86dubjxg5[Awaiting Merge]